### PR TITLE
Remove key props from inputs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,7 +76,6 @@ function App() {
                   First name
                   <input
                     value={firstName}
-                    key={firstName}
                     onChange={(event) => setFirstName(event.target.value)}
                     disabled={disabled}
                   />
@@ -87,7 +86,6 @@ function App() {
                   Last name
                   <input
                     value={lastName}
-                    key={lastName}
                     onChange={(event) => setLastName(event.target.value)}
                     onKeyPress={(event) => handleKeyDown(event)}
                     disabled={disabled}


### PR DESCRIPTION
This was causing the input to lose focus on every keypress, because the `key` (which is the reference that React uses to refer to the element) changed every time that someone changed the value in the input

Probably also why Drone is failing